### PR TITLE
Fix for https://github.com/mardix/flask-cloudy/issues/2

### DIFF
--- a/flask_cloudy.py
+++ b/flask_cloudy.py
@@ -308,7 +308,7 @@ class Storage(object):
             raise InvalidExtensionError("Invalid file extension: '.%s' " % extension)
 
         if isinstance(file, FileStorage):
-            obj = self.container.upload_object_via_stream(iterator=file,
+            obj = self.container.upload_object_via_stream(iterator=file.stream,
                                                           object_name=name,
                                                           extra=extra)
         else:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "Flask==0.10.1",
-        "apache-libcloud==0.18.0",
+        "apache-libcloud==0.19.0",
         "lockfile==0.10.2",
         "shortuuid==0.1",
         "six==1.9.0",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "Flask==0.10.1",
-        "apache-libcloud==0.17.0",
+        "apache-libcloud==0.18.0",
         "lockfile==0.10.2",
         "shortuuid==0.1",
         "six==1.9.0",

--- a/tests/test_cloudy.py
+++ b/tests/test_cloudy.py
@@ -165,3 +165,19 @@ def test_save_to():
     assert os.path.isfile(file)
     assert file2 == CWD + "/data/my_new_file.txt"
 
+def test_werkzeug_upload():
+    try:
+        import werkzeug
+    except ImportError:
+        return
+    storage = app_storage()
+    object_name = "my-txt-hello.txt"
+    filepath = CWD + "/data/hello.txt"
+    file = None
+    with open(filepath, 'rb') as fp:
+        file = werkzeug.datastructures.FileStorage(fp)
+        file.filename = object_name
+        o = storage.upload(file, overwrite=True)
+        assert isinstance(o, Object)
+        assert o.name == object_name
+


### PR DESCRIPTION
These changes should resolve https://github.com/mardix/flask-cloudy/issues/2. But unfortunately https://github.com/apache/libcloud/pull/568 is not released on PyPI now, so development version of apache-libcloud is required.