### PR TITLE
if obj => if obj is not None

### DIFF
--- a/flask_cloudy.py
+++ b/flask_cloudy.py
@@ -347,7 +347,7 @@ class Storage(object):
                 @app.route(url, endpoint=SERVER_ENDPOINT)
                 def files_server(object_name):
                     obj = self.get(object_name)
-                    if obj:
+                    if obj is not None:
                         dl = request.args.get("dl")
                         name = request.args.get("name", obj.name)
 


### PR DESCRIPTION
The file server was returning a 404 on every file because bool(obj)==False. This is because python falls back on __len__ which is set to zero for most files. This fixes it.