### PR TITLE
support for adding extra param to create driver

### DIFF
--- a/flask_cloudy.py
+++ b/flask_cloudy.py
@@ -204,6 +204,7 @@ class Storage(object):
         allowed_extensions = app.config.get("STORAGE_ALLOWED_EXTENSIONS", None)
         serve_files = app.config.get("STORAGE_SERVER", True)
         serve_files_url = app.config.get("STORAGE_SERVER_URL", "files")
+        extra_params = app.config.get("STORAGE_EXTRA", {})
 
         self.config["serve_files"] = serve_files
         self.config["serve_files_url"] = serve_files_url
@@ -220,7 +221,8 @@ class Storage(object):
                       key=key,
                       secret=secret,
                       container=container,
-                      allowed_extensions=allowed_extensions)
+                      allowed_extensions=allowed_extensions,
+                      **extra_params)
 
         self._register_file_server(app)
 
@@ -397,7 +399,7 @@ class Object(object):
 
     def get_url(self, secure=False, longurl=False):
         """
-        Return the url 
+        Return the url
         :param secure: bool - To use https
         :param longurl: bool - On local, reference the local path with the domain
                         ie: http://site.com/files/object.png otherwise /files/object.png


### PR DESCRIPTION
Some providers need (e.g., [OpenStack swift](http://libcloud.readthedocs.org/en/latest/storage/drivers/openstack_swift.html) ) extra parameters while
creating the driver. This will allow passing extra parameters to the
storage object through STORAGE_EXTRA key of the config object.

Following example demonstrates how to connect to a local  [swift all-in-one](http://docs.openstack.org/developer/swift/development_saio.html) cluster:

In `app.py`

``` python

import swiftclient.client as client

USER='test:tester'
PASS='testing'
AUTH_URL='http://localhost:8080/auth/v1.0'

STORAGE_URL, AUTH_TOKEN = client.get_auth(auth_url=AUTH_URL,user=USER,key=PASS)

app.config.update({
    "STORAGE_PROVIDER": "OPENSTACK_SWIFT",
    "STORAGE_CONTAINER": "some_container",
    "STORAGE_KEY": USER,
    "STORAGE_SECRET": PASS,
    "STORAGE_SERVER": STORAGE_URL,
    "STORAGE_EXTRA": {
        "ex_force_auth_token": AUTH_TOKEN, # The the exact parameter name the driver expects
        "ex_force_base_url":STORAGE_URL,
        "secure": False
    }
})

storage = Storage()
storage.init_app(app)

```
