### PR TITLE
Fix EncodeError: Encode Secret & Upgrade libcloud

### DIFF
--- a/flask_cloudy.py
+++ b/flask_cloudy.py
@@ -582,7 +582,7 @@ class Object(object):
 
                 s2s = "GET\n\n\n{expires}\n/{object_name}"\
                     .format(expires=expires, object_name=self.path)
-                h = hmac.new(self.driver.secret, s2s, hashlib.sha1)
+                h = hmac.new(self.driver.secret.encode('utf-8'), s2s.encode('utf-8'), hashlib.sha1)
                 s = base64.encodestring(h.digest()).strip()
                 _keyIdName = "AWSAccessKeyId" if "s3" in driver_name else "GoogleAccessId"
                 params = {

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "Flask>=0.10.1",
-        "apache-libcloud==0.20.0",
+        "apache-libcloud==1.5.0",
         "lockfile==0.10.2",
         "shortuuid==0.1",
         "six==1.9.0",


### PR DESCRIPTION
Python 3:  The call to `hmac` in `Object.download_url` would result in:
> TypeError: Unicode-objects must be encoded before hashing

This encodes the secret and the `s2s` string before passing it into hmac. 

2aa0a14304ea311c05a9d2b1ddca9db6dc2d82bf upgrades the libcloud dependency to the latest version. There are many bug fixes (including ones that affect the ability to login to Google Storage with service accounts) 

In case you aren't comfortable with going all the way to `1.5.0` - there's a patch upgrade available in `libcloud==0.20.1` that addresses the google authentication issue mentioned earlier. 
