### PR TITLE
Allow apache-libcloud update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "Flask>=0.10.1",
-        "apache-libcloud==0.20.1",
+        "apache-libcloud>=0.20.1",
         "lockfile>=0.10.2",
         "six>=1.9.0",
         'python-slugify>=1.2.1'


### PR DESCRIPTION
After updating from python 2.7 to python 3.6 to get some other lib fixes, faced with issue:
```
MalformedResponseError: <MalformedResponseException in 
<libcloud.storage.drivers.google_storage.GoogleStorageDriver object at 0x7f083bd74470> 
'Failed to parse XML'>:
```
Suggest unpin apache-libcloud varsion. 

Last version of apache-libcloud==2.6.0 is working for me. 
